### PR TITLE
Fix grammar in 4.4.md

### DIFF
--- a/docs/website/4.4.md
+++ b/docs/website/4.4.md
@@ -5,7 +5,7 @@ hide_table_of_contents: true
 
 # Regarding Scratch Terms of Use Section 4.4
 
-Some people have noticed that Scratch's [Terms of Use](https://scratch.mit.edu/terms_of_use) includes these texts:
+Some people have noticed that Scratch's [Terms of Use](https://scratch.mit.edu/terms_of_use) includes this section:
 
 > 4.4 You may only submit user-generated projects that were created with (1) the Scratch website editor or (2) an unmodified copy of the Scratch editor compiled from the source code described in Section 5.3. You may not upload any projects that were created, by you or by anyone else, with a modified version of the Scratch editor.
 


### PR DESCRIPTION
Now that 5.3 is not quoted directly after 4.4, "these texts" only refers to 4.4 so it's grammatically incorrect. "This text" sounded off so I used "this section".