### PR TITLE
Fix some typos in the extension docs

### DIFF
--- a/docs/development/extensions/assorted-apis.md
+++ b/docs/development/extensions/assorted-apis.md
@@ -70,7 +70,7 @@ Each of these properties should be inline [data: URLs](https://developer.mozilla
 
 ## Inline images
 
-You can also put images anywhere in a block using an "argument" of type IMAGE and setting `dataURI` on the argument. Like the other images, this is a [data: URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). SVG is preferred, but PNG or JPG at least 64x64 in size also works well. Icons should be square.
+You can also put images anywhere in a block using an "argument" of type IMAGE and setting `dataURI` on the argument. Like the other images, this is a [data: URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). SVG is preferred, but PNG or JPG at least 64x64 in size also works well. Icons should be square.
 
 Additionally, if you set `flipRTL` to true, the image will be horizontally flipped in right-to-left languages.
 

--- a/docs/development/extensions/hello-world.md
+++ b/docs/development/extensions/hello-world.md
@@ -82,7 +82,7 @@ These are the acceptable values for blockType:
 |Scratch.BlockType.COMMAND|A block that doesn't report a value|move 10 steps|
 |Scratch.BlockType.REPORTER|A round block that reports a string or number|x position, costume name|
 |Scratch.BlockType.BOOLEAN|A block with pointy edges that reports a boolean (true or false)|mouse down|
-|Scratch.BlockType.HAT|An block that starts in response to events. Discussed later.|when this sprite clicked|
+|Scratch.BlockType.HAT|A block that starts in response to events. Discussed later.|when this sprite clicked|
 
 While other BlockTypes do exist, they do not work well and will not be discussed at this time.
 
@@ -94,7 +94,7 @@ While other BlockTypes do exist, they do not work well and will not be discussed
   }
 ```
 
-This defines the function that will run the block with the opcode "hello" runs. In this case, our block is very simple and just returns a string. REPORTER blocks are expected to return a string, number, or boolean, and BOOLEAN blocks are expected to only return a boolean. Note that `null`, `undefined`, lists, and objects are not expected return values for these blocks.
+This defines the function that will run the block with the opcode "hello". In this case, our block is very simple and just returns a string. REPORTER blocks are expected to return a string, number, or boolean, and BOOLEAN blocks are expected to only return a boolean. Note that `null`, `undefined`, lists, and objects are not expected return values for these blocks.
 
 When you want to change the extension, simply modify the extension and reload the page. Here's a tip to make your life easier: You can use the `?extension=` URL parameter to load an extension automatically instead of requiring going into the library. For example, if your extension URL is http://localhost:8080/hello-world.js, you could use https://turbowarp.org/editor?extension=http://localhost:8080/hello-world.js to load it automatically.
 

--- a/docs/development/extensions/introduction.md
+++ b/docs/development/extensions/introduction.md
@@ -57,7 +57,7 @@ This will start a local HTTP server on http://localhost:8080/ in whatever folder
 
 We will eventually introduce the official development server, but given that this is a fundamentals-up tutorial, we will start using the most primitive server possible.
 
-For now, you should use a part **other than 8000**. We will talk more about this later, but for now we want the extensions you write to run in the sandbox. We will talk about what this means later.
+For now, you should use a port **other than 8000**. We will talk more about this later, but for now we want the extensions you write to run in the sandbox. We will talk about what this means later.
 
 Create a file called `hello-world.js` and put any text in it (we will discuss what to put in it later). Make sure you're able to read the contents of the file in your browser by visiting a link like [http://localhost:8080/hello-world.js](http://localhost:8080/hello-world.js).
 

--- a/docs/development/extensions/sandbox.md
+++ b/docs/development/extensions/sandbox.md
@@ -23,7 +23,7 @@ For this reason, sandboxed extensions:
 
 They can, however:
 
- - Access most public APIs, as long as [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) allows
+ - Access most public APIs, as long as [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) allows it
  - Access some JavaScript Web APIs, such as the [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/Using_the_Gamepad_API)
 
 It is worthwhile to note that in other Scratch mods, the extension sandbox may be a `Worker` instead of an `<iframe>`. We use an `<iframe>` instead as it is more secure (cross origin vs. same origin) and allows access to more Web APIs.


### PR DESCRIPTION
I didn't want to modify it to much, this just fixes a few typos and a couple other minor things.