### PR TITLE
extensions.json instead of index.ejs

### DIFF
--- a/docs/development/extensions/better-development-server.md
+++ b/docs/development/extensions/better-development-server.md
@@ -39,7 +39,7 @@ In the future, we may consider adding more development features.
 ## Exercises
 
 1. Can you figure out how to add a new HTML file to the development server? (Hint: <Spoiler>look into the "website" folder</Spoiler>)
-1. Can you figure out how to add your extension to the homepage list? (Hint: <Spoiler>look at "website/index.ejs"</Spoiler>)
+1. Can you figure out how to add your extension to the homepage list? (Hint: <Spoiler>look at "extensions/extensions.json"</Spoiler>)
 1. Can you figure out how to add an image for your extension on the homepage? (Hint: <Spoiler>create an image in "images" with the same folder and basename as the file in "extensions"</Spoiler>)
 
 ## Next steps


### PR DESCRIPTION
In the excercises section of https://docs.turbowarp.org/development/extensions/better-development-server is told to look at ``website/index.ejs`` while that file doesn't exist and has been replaced by ``extensions/extensions.json``.