### PR TITLE
Make contributing to docs easier

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,7 +55,9 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/',
-          editUrl: 'https://github.com/TurboWarp/docs/edit/master/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/TurboWarp/docs/master/editor/docs/${docPath}`
+          },
           breadcrumbs: false,
         },
         theme: {


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/TurboWarp/docs/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb